### PR TITLE
fix: the copy-source in copy-source.mjs

### DIFF
--- a/validation/sandbox/copy-source.mjs
+++ b/validation/sandbox/copy-source.mjs
@@ -3,7 +3,7 @@ import { dirname, join, resolve } from 'node:path'
 
 const source = resolve(process.argv[2] ?? '')
 const destination = resolve(process.argv[3] ?? '')
-if (!source || !destination.startsWith('/validation/workspace/')) throw new Error('Invalid copy boundary')
+if (!source.startsWith('/source') || !destination.startsWith('/validation/workspace/')) throw new Error('Invalid copy boundary')
 
 async function rejectLinks(path) {
   for (const name of await readdir(path)) {


### PR DESCRIPTION
## Summary
Fix high severity security issue in `validation/sandbox/copy-source.mjs`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `validation/sandbox/copy-source.mjs:4` |
| **Assessment** | Likely exploitable |

**Description**: The copy-source.mjs script accepts a source path via command-line argument and uses resolve() without proper validation. While the destination path is validated to start with '/validation/workspace/', the source path lacks equivalent validation, allowing attackers to read arbitrary files from the host system.

## Evidence

**Exploitation scenario**: Execute the script with a path traversal payload: node copy-source.mjs '../../../etc/passwd' '/validation/workspace/target'.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `validation/sandbox/copy-source.mjs`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
